### PR TITLE
Fix math rendering bugs

### DIFF
--- a/datasets/convective_envelope_rsg/README.md
+++ b/datasets/convective_envelope_rsg/README.md
@@ -12,14 +12,19 @@
 
 **Equations**
 
-```math
+$$
 \begin{align*}
 \frac{\partial\rho}{\partial t}+\mathbf{\nabla}\cdot(\rho\mathbf{v})&=0\\
-\frac{\partial(\rho\mathbf{v})}{\partial t}+\mathbf{\nabla}\cdot({\rho\mathbf{v}\mathbf{v}+{{\sf P_{\rm gas}}}}) &=-\mathbf{G}_r-\rho\mathbf{\nabla}\Phi \\
-\frac{\partial{E}}{\partial t}+\mathbf{\nabla}\cdot\left[(E+ P_{\rm gas})\mathbf{v}\right] &= -c G^0_r -\rho\mathbf{v}\cdot\mathbf{\nabla}\Phi\\
+\frac{\partial(\rho\mathbf{v})}{\partial t}+\mathbf{\nabla}\cdot({\rho\mathbf{v}\mathbf{v}+{{\sf P_{\rm gas}}}}) &=-\mathbf{G}_r-\rho\mathbf{\nabla}\Phi
+\end{align*}
+$$
+
+$$
+\begin{align*}
+\frac{\partial{E}}{\partial t}+\mathbf{\nabla}\cdot\left[(E+ P_{\rm gas})\mathbf{v}\right] &= -c G^0_r -\rho\mathbf{v}\cdot\mathbf{\nabla}\Phi \\
 \frac{\partial I}{\partial t}+c\mathbf{n}\cdot\mathbf{\nabla} I &= S(I,\mathbf{n})
 \end{align*}
-```
+$$
 
 where
 

--- a/datasets/euler_multi_quadrants_openBC/README.md
+++ b/datasets/euler_multi_quadrants_openBC/README.md
@@ -14,12 +14,25 @@
 
 **Equation**: Euler equations for a compressible gas:
 
-```math
-\begin{align}
-U_t + F(U)_x + G(U)_y &= 0 \nonumber\\
-\textrm{where} \quad U = \begin{bmatrix} \rho \nonumber\\ \rho u \\ \rho v \\ e \end{bmatrix}, \quad F(U) = \begin{bmatrix} \rho u \\ \rho u^2 + p \\ \rho u v \\ u(e + p) \end{bmatrix},& \quad G(U) = \begin{bmatrix} \rho v \\ \rho u v \\ \rho v^2 + p \\ v(e + p) \end{bmatrix}, \quad \\ e = \frac{p}{(\gamma - 1)} + \frac{\rho (u^2 + v^2)}{2}&, \quad p = A\rho^{\gamma}. \nonumber
-\end{align}
-```
+$$
+\begin{align*}
+U_t + F(U)_x + G(U)_y &= 0 \\
+\textrm{where} \quad U = \begin{bmatrix}
+\rho \\
+\rho u \\
+\rho v \\
+e \end{bmatrix}, \quad F(U) = \begin{bmatrix}
+\rho u \\
+\rho u^2 + p \\
+\rho u v \\
+u(e + p) \end{bmatrix},& \quad G(U) = \begin{bmatrix}
+\rho v \\
+\rho u v \\
+\rho v^2 + p \\
+v(e + p) \end{bmatrix}, \quad \\
+e = \frac{p}{(\gamma - 1)} + \frac{\rho (u^2 + v^2)}{2}&, \quad p = A\rho^{\gamma}.
+\end{align*}
+$$
 
 with $\rho$ the density, $u$ and $v$ the $x$ and $y$ velocity components, $e$ the energy, $p$ the pressure, $\gamma$ the gas constant, and $A>0$ is a function of entropy.
 

--- a/datasets/euler_multi_quadrants_periodicBC/README.md
+++ b/datasets/euler_multi_quadrants_periodicBC/README.md
@@ -14,12 +14,25 @@
 
 **Equation**: Euler equations for a compressible gas:
 
-```math
-\begin{align}
-U_t + F(U)_x + G(U)_y &= 0 \nonumber\\
-\textrm{where} \quad U = \begin{bmatrix} \rho \nonumber\\ \rho u \\ \rho v \\ e \end{bmatrix}, \quad F(U) = \begin{bmatrix} \rho u \\ \rho u^2 + p \\ \rho u v \\ u(e + p) \end{bmatrix},& \quad G(U) = \begin{bmatrix} \rho v \\ \rho u v \\ \rho v^2 + p \\ v(e + p) \end{bmatrix}, \quad \\ e = \frac{p}{(\gamma - 1)} + \frac{\rho (u^2 + v^2)}{2}&, \quad p = A\rho^{\gamma}. \nonumber
-\end{align}
-```
+$$
+\begin{align*}
+U_t + F(U)_x + G(U)_y &= 0 \\
+\textrm{where} \quad U = \begin{bmatrix}
+\rho \\
+\rho u \\
+\rho v \\
+e \end{bmatrix}, \quad F(U) = \begin{bmatrix}
+\rho u \\
+\rho u^2 + p \\
+\rho u v \\
+u(e + p) \end{bmatrix},& \quad G(U) = \begin{bmatrix}
+\rho v \\
+\rho u v \\
+\rho v^2 + p \\
+v(e + p) \end{bmatrix}, \quad \\
+e = \frac{p}{(\gamma - 1)} + \frac{\rho (u^2 + v^2)}{2}&, \quad p = A\rho^{\gamma}.
+\end{align*}
+$$
 
 with $\rho$ the density, $u$ and $v$ the $x$ and $y$ velocity components, $e$ the energy, $p$ the pressure, $\gamma$ the gas constant, and $A>0$ is a function of entropy.
 

--- a/datasets/gray_scott_reaction_diffusion/README.md
+++ b/datasets/gray_scott_reaction_diffusion/README.md
@@ -12,11 +12,12 @@
 
 **Equation describing the data**
 
-```math
+$$
 \begin{align*}
-\frac{\partial A}{\partial t} &= \delta_A\Delta A - AB^2 + f(1-A) \\ \frac{\partial B}{\partial t} &= \delta_B\Delta B - AB^2 - (f+k)B
+\frac{\partial A}{\partial t} &= \delta_A\Delta A - AB^2 + f(1-A) \\
+\frac{\partial B}{\partial t} &= \delta_B\Delta B - AB^2 - (f+k)B
 \end{align*}
-```
+$$
 
 The dimensionless parameters describing the behavior are: $f$ the rate at which $A$ is replenished (feed rate), $k$ the rate at which $B$ is removed from the system, and  $\delta_A, \delta_B$ the diffusion coefficients of both species.
 

--- a/datasets/post_neutron_star_merger/README.md
+++ b/datasets/post_neutron_star_merger/README.md
@@ -14,24 +14,25 @@
 
 The fluid sector consists of the following system of equations.
 
-```math
+$$
 \begin{align*}
-  \partial_t \left(\sqrt{g}\rho_0 u^t\right) + \partial_i\left(\sqrt{g}\rho_0u^i\right)
-  &= 0\\
-  \partial_t\left[\sqrt{g} \left(T^t_{\ \nu} + \rho_0u^t \delta^t_\nu\right)\right]
-  + \partial_i\left[\sqrt{g}\left(T^i_{\ \nu} + \rho_0 u^i \delta^t_\nu\right)\right]
-  &= \sqrt{g} \left(T^\kappa_{\ \lambda} \Gamma^\lambda_{\nu\kappa} + G_\nu\right)\,\,\,\, \forall \nu = 0,1,\ldots,4\\
-  \partial_t \left(\sqrt{g} B^i\right) + \partial_j \left[\sqrt{g}\left(b^ju^i - b^i u^j\right)\right] &= 0\\
-  \partial_t\left(\sqrt{g}\rho_0 Y_e u^t\right) + \partial_i\left(\sqrt{g}\rho_0Y_eu^i\right)
-  &= \sqrt{g} G_{\text{ye}}
+  \partial_t \left(\sqrt{g}\rho_0 u^t\right) + \partial_i\left(\sqrt{g}\rho_0u^i\right) &= 0 \\
+  \partial_t\left[\sqrt{g} \left(T^t_{\ \nu} + \rho_0u^t \delta^t_\nu\right)\right] + \partial_i\left[\sqrt{g}\left(T^i_{\ \nu} + \rho_0 u^i \delta^t_\nu\right)\right] &= \sqrt{g} \left(T^\kappa_{\ \lambda} \Gamma^\lambda_{\nu\kappa} + G_\nu\right)\,\,\,\, \forall \nu = 0,1,\ldots,4
 \end{align*}
-```
+$$
+
+$$
+\begin{align*}
+  \partial_t \left(\sqrt{g} B^i\right) + \partial_j \left[\sqrt{g}\left(b^ju^i - b^i u^j\right)\right] &= 0 \\
+  \partial_t\left(\sqrt{g}\rho_0 Y_e u^t\right) + \partial_i\left(\sqrt{g}\rho_0Y_eu^i\right) &= \sqrt{g} G_{\text{ye}}
+\end{align*}
+$$
 
 The standard radiative transfer equation is
 
-```math
-  \frac{D}{d\lambda}\left(\frac{h^3\mathcal{I}_{\nu,f}}{\varepsilon^3}\right) = \left(\frac{h^2\eta_{\nu,f}}{\varepsilon^2}\right) - \left(\frac{\varepsilon \chi_{\nu,f}}{h}\right) \left(\frac{h^3\mathcal{I}_{\nu,f}}{\varepsilon^3}\right)
-```
+$$
+\frac{D}{d\lambda}\left(\frac{h^3\mathcal{I}_{\nu,f}}{\varepsilon^3}\right) = \left(\frac{h^2\eta _{\nu,f}}{\varepsilon^2}\right) - \left(\frac{\varepsilon \chi _{\nu,f}}{h}\right) \left(\frac{h^3\mathcal{I} _{\nu,f}}{\varepsilon^3}\right)
+$$
 
 <p align="center"> <img src="https://users.flatironinstitute.org/~polymathic/data/the_well/datasets/post_neutron_star_merger/gif/Ye_good_normalized.gif" width="50%"></p>
 

--- a/datasets/viscoelastic_instability/README.md
+++ b/datasets/viscoelastic_instability/README.md
@@ -12,17 +12,22 @@
 
 **Equation**:
 
-```math
+$$
 \begin{align*}
-Re(\partial_t \mathbf{u^*} + (\mathbf{u^*}\cdot\nabla)\mathbf{u^*} ) + \nabla p^* &= \beta \Delta \mathbf{u^*} + (1-\beta)\nabla\cdot \mathbf{T}(\mathbf{C^*}),\\
-\partial_t \mathbf{C^*} + (\mathbf{u^*}\cdot\nabla)\mathbf{C^*} +\mathbf{T}(\mathbf{C^*}) &= \mathbf{C^*}\cdot\nabla \mathbf{u^*} + (\nabla \mathbf{u^*})^T \cdot \mathbf{C^*} + \epsilon \Delta \mathbf{C^*}, \\
-\nabla \mathbf{u^*} &= 0,\\
-\textrm{with} \quad \mathbf{T}(\mathbf{C^*}) &= \frac{1}{\text{Wi}}(f(\textrm{tr}(\mathbf{C^*}))\mathbf{C^*} - \mathbf{I}),\\
+Re(\partial_t \mathbf{u^\ast} + (\mathbf{u^\ast}\cdot\nabla)\mathbf{u^\ast} ) + \nabla p^\ast &= \beta \Delta \mathbf{u^\ast} + (1-\beta)\nabla\cdot \mathbf{T}(\mathbf{C^\ast}),\\
+\partial_t \mathbf{C^\ast} + (\mathbf{u^\ast}\cdot\nabla)\mathbf{C^\ast} +\mathbf{T}(\mathbf{C^\ast}) &= \mathbf{C^\ast}\cdot\nabla \mathbf{u^\ast} + (\nabla \mathbf{u^\ast})^T \cdot \mathbf{C^\ast} + \epsilon \Delta \mathbf{C^\ast}, \\
+\nabla \mathbf{u^\ast} &= 0,
+\end{align*}
+$$
+
+$$
+\begin{align*}
+\textrm{with} \quad \mathbf{T}(\mathbf{C^\ast}) &= \frac{1}{\text{Wi}}(f(\textrm{tr}(\mathbf{C^\ast}))\mathbf{C^\ast} - \mathbf{I}),\\
 \textrm{and} \quad f(s) &:= \left(1- \frac{s-3}{L^2_{max}}\right)^{-1}.
 \end{align*}
-```
+$$
 
-where $\mathbf{u^*} = (u^*,v^*)$ is the streamwise and wall-normal velocity components, $p^*$ is the pressure, $\mathbf{C^*}$ is the positive definite conformation tensor which represents the ensemble average of the produce of the end-to-end vector of the polymer molecules. In 2D, 4 components of the tensor are solved: $c_{xx}^{*}, c^{*}_{yy}, c^{*}_{zz}, c^{*}_{xy}$. $\mathbf{T}(\mathbf{C^{*}})$ is the polymer stress tensor given by the FENE-P model.
+where $\mathbf{u^\ast} = (u^\ast,v^\ast)$ is the streamwise and wall-normal velocity components, $p^\ast$ is the pressure, $\mathbf{C^\ast}$ is the positive definite conformation tensor which represents the ensemble average of the produce of the end-to-end vector of the polymer molecules. In 2D, 4 components of the tensor are solved: $c_{xx}^\ast, c_{yy}^\ast, c_{zz}^\ast, c_{xy}^\ast$. $\mathbf{T}(\mathbf{C^\ast})$ is the polymer stress tensor given by the FENE-P model.
 
 
 ![Gif](https://users.flatironinstitute.org/~polymathic/data/the_well/datasets/viscoelastic_instability/gif/czz_normalized.gif)
@@ -44,7 +49,7 @@ Table: VRMSE metrics on test sets (lower is better). Best results are shown in b
 - Transition to chaos between EIT and Laminar: 43 snapshots with 20 timesteps of 512x512 images.
 - Transition to non-chaotic state between EIT and Laminar: 49 snapshots with 20 timesteps of 512x512 images.
 
-**Fields available in the data:** pressure (scalar field), velocity (vector field), positive conformation tensor ( $c_{xx}^{*}, c^{*}_{yy},, c^{*}_{xy}$ are in tensor fields, $c^{*}_{zz}$ in scalar fields).
+**Fields available in the data:** pressure (scalar field), velocity (vector field), positive conformation tensor ( $c_{xx}^\ast, c_{yy}^\ast, c_{xy}^\ast$ are in tensor fields, $c_{zz}^\ast$ in scalar fields).
 
 **Number of trajectories:** 260 trajectories.
 
@@ -58,7 +63,7 @@ Table: VRMSE metrics on test sets (lower is better). Best results are shown in b
 - EIT: laminar state + blowing and suction at the walls.
 - CAR: SAR + blowing and suction at the walls.
 
-**Boundary conditions:** no slip conditions for the velocity $(u^*,v^*)=(0,0)$ at the wall and $\epsilon=0$ at the wall for the equation for $\mathbf{C^*}$.
+**Boundary conditions:** no slip conditions for the velocity $(u^\ast,v^\ast)=(0,0)$ at the wall and $\epsilon=0$ at the wall for the equation for $\mathbf{C^\ast}$.
 
 **Simulation time-step:** various in the different states, but typically $\sim 10^{-4}$.
 


### PR DESCRIPTION
As math blocks are not supported by `mkdocs`, we should always use `$$`. However, GitHub's math rendering does not work perfectly with `$$`. Apparently,

1. `\begin{align*}` blocks should contain at most 3 lines.
2. A math line should be written on a single code line.
3. Every `\\` should be followed by one and only one line return (even in `bmatrix`).
4. Somehow `\chi_{\nu}` does not work but `\chi _{\nu}` does :shrug:
5. `^*` should be replaced with `^\ast`.