### PR TITLE
Test model availability on HF

### DIFF
--- a/tests/models/test_hf_availability.py
+++ b/tests/models/test_hf_availability.py
@@ -1,0 +1,11 @@
+import pytest
+from huggingface_hub import PyTorchModelHubMixin
+
+from the_well.benchmark.models import FNO, TFNO, UNetClassic, UNetConvNext
+
+
+@pytest.mark.parametrize("model_cls", [FNO, TFNO, UNetClassic, UNetConvNext])
+@pytest.mark.parametrize("dataset", ["active_matter", "turbulent_radiative_layer_2D"])
+def test_model_is_available_on_hf(model_cls: PyTorchModelHubMixin, dataset: str):
+    model = model_cls.from_pretrained(f"polymathic-ai/{model_cls.__name__}-{dataset}")
+    assert isinstance(model, model_cls)


### PR DESCRIPTION
This PR adds test to check models are actually available on HF.
It only tests the 4 models for 2 datasets to limit test running time.