### PR TITLE
added max rollout steps to dataset docstring

### DIFF
--- a/the_well/data/datasets.py
+++ b/the_well/data/datasets.py
@@ -136,6 +136,9 @@ class WellDataset(Dataset):
             Whether to normalize data in the dataset
         normlization_type:
             What type of dataset normalization. Callable Options: ZSCORE and RMS
+        max_rollout_steps:
+            Maximum number of output steps to return in a single sample, mostly used for
+            full trajectory mode.
         n_steps_input:
             Number of steps to include in each sample
         n_steps_output:


### PR DESCRIPTION
Hi guys,

I realized that the parameter [max_rollout_steps](https://github.com/PolymathicAI/the_well/blob/6d77553100b6063e5c23cfb9c0586448265ee72a/the_well/data/datasets.py#L185) is not present in the dataset docstring nor the docs on the website. This lead to some confusion since we wanted to get a full 500 step trajectory.

Best,
Florian
