### PR TITLE
Add missing symbolic link to rayleigh_benard_uniform

### DIFF
--- a/docs/datasets/rayleigh_benard_uniform.md
+++ b/docs/datasets/rayleigh_benard_uniform.md
@@ -1,0 +1,1 @@
+../../datasets/rayleigh_benard_uniform/README.md


### PR DESCRIPTION
Fixes #55 

The `mkdocs.yml` file references a file that does not exist. This PR creates this file as a symbolic link to `datasets/rayleigh_benard_uniform/README.md`.

https://github.com/PolymathicAI/the_well/blob/a65f5bf5b43d3c7737c4725165d904bd79c5dcd3/mkdocs.yml#L39