### PR TITLE
fix: stop overwriting `best.pt` every validation

### DIFF
--- a/the_well/benchmark/trainer/training.py
+++ b/the_well/benchmark/trainer/training.py
@@ -460,6 +460,7 @@ class Trainer:
                     self.save_model(
                         epoch, val_loss, os.path.join(self.checkpoint_folder, "best.pt")
                     )
+                    self.best_val_loss = val_loss
             # Check if time for expensive validation - periodic or final
             if epoch % self.rollout_val_frequency == 0 or (epoch == self.max_epoch):
                 logger.info(


### PR DESCRIPTION
`self.best_val_loss` is never set, so `self.best_val_loss is None` is always `True`, which causes the `best.pt` checkpoint to be overwritten every validation step during training.