### PR TITLE
fix: denominator calculation for short validation

### DIFF
--- a/the_well/benchmark/trainer/training.py
+++ b/the_well/benchmark/trainer/training.py
@@ -314,7 +314,11 @@ class Trainer:
         loss_dict = {}
         time_logs = {}
         count = 0
-        denom = len(dataloader) if full else min(self.short_validation_length, len(dataloader))
+        denom = (
+            len(dataloader)
+            if full
+            else min(self.short_validation_length, len(dataloader))
+        )
         with torch.autocast(
             self.device.type, enabled=self.enable_amp, dtype=self.amp_type
         ):


### PR DESCRIPTION
This causes the model to report wrong validation scores if the batch size is large enough such that `self.short_validation_length * batch_size > len(validation_dset)`.