### PR TITLE
add option to exclude specific indices from the dataset

### DIFF
--- a/tests/data/test_dataset.py
+++ b/tests/data/test_dataset.py
@@ -327,6 +327,41 @@ def test_restricted_samples_float(tmp_path):
     assert data is not None
 
 
+def test_restricted_indices(tmp_path):
+    filename = tmp_path / "dummy_well_data.hdf5"
+    write_dummy_data(filename)
+    # Create dataset without restrictions to get the full length
+    full_dataset = WellDataset(
+        path=str(tmp_path),
+        use_normalization=False,
+        return_grid=True,
+    )
+    full_length = len(full_dataset)
+
+    # Exclude specific indices
+    indices_to_exclude = [0, 1, 5, 10]
+    dataset = WellDataset(
+        path=str(tmp_path),
+        use_normalization=False,
+        return_grid=True,
+        restrict_indices=indices_to_exclude,
+    )
+
+    expected_length = full_length - len(indices_to_exclude)
+    assert (
+        len(dataset) == expected_length
+    ), f"Restricted dataset should contain {expected_length} samples (18 - 4 excluded), but found {len(dataset)}"
+
+    # Verify we can still access data
+    data = dataset[0]
+    assert data is not None
+
+    # Verify that the restriction set doesn't contain excluded indices
+    assert all(
+        idx not in indices_to_exclude for idx in dataset.restriction_set
+    ), "Restriction set should not contain any excluded indices"
+
+
 @pytest.mark.parametrize("start_output_steps_at_t", [-1, 4])
 def test_full_trajectory_mode_minimum_steps(tmp_path, start_output_steps_at_t):
     filename = tmp_path / "dummy_well_data.hdf5"


### PR DESCRIPTION
Currently, we can restrict the number of samples/trajectories for each dataset using the ``restrict_num_samples`` or ``restrict_num_trajectories``  parameters.

If you agree, I'd like to enable an option to pass a list of indices to skip as a third option in the [_build_restriction_set](https://github.com/PolymathicAI/the_well/blob/6cd3c44ef832855a5abae87d555bf0f0f52b1fa7/the_well/data/datasets.py#L349) method. 

That way, we can skip faulty or useless samples. On example are the steady-state solutions in the gray-scott dataset, which might distort training. Now we can just precompute/list the the indices to remove.


