### PR TITLE
Fix Windows path resolution for normalization_path

### DIFF
--- a/the_well/data/datasets.py
+++ b/the_well/data/datasets.py
@@ -247,7 +247,7 @@ class WellDataset(Dataset):
         else:
             self.normalization_path = os.path.join(
                 trunk_path,
-                str(normalization_path).removeprefix(str(trunk_path)).lstrip("./"),
+                str(normalization_path).removeprefix(str(trunk_path)).lstrip("./\\"),
             )
 
         self.fs, _ = fsspec.url_to_fs(self.data_path, **(storage_options or {}))


### PR DESCRIPTION
## Summary

The normalization path refactor introduced in #69 breaks on Windows due to a platform-specific path separator issue.

`.lstrip("./")` on [this line](https://github.com/PolymathicAI/the_well/blob/master/the_well/data/datasets.py#L250) only strips Unix-style separators (`.` and `/`). On Windows, `os.path.join` produces backslash-separated paths, so `.removeprefix(trunk_path)` leaves a leading `\` (e.g. `\stats.yaml`), which `.lstrip("./")` does not strip. When this is passed to `os.path.join`, Windows interprets the leading `\` as a drive-root path, resolving to `C:\stats.yaml` instead of the correct dataset-relative path.

### Fix

Adding `\` to the lstrip characters: `.lstrip("./\\")` — this has no effect on macOS/Linux since backslashes don't appear in paths there.

### Steps to reproduce

1. On Windows, configure `well_base_path` as a relative path (e.g. `../../datasets/`)
2. Run training with `use_normalization=True`
3. `normalization_path` incorrectly resolves to `C:\stats.yaml`

