### PR TITLE
Fix sign error in Gray-Scott equation in dataset README

### DIFF
--- a/datasets/gray_scott_reaction_diffusion/README.md
+++ b/datasets/gray_scott_reaction_diffusion/README.md
@@ -15,7 +15,7 @@
 $$
 \begin{align*}
 \frac{\partial A}{\partial t} &= \delta_A\Delta A - AB^2 + f(1-A) \\
-\frac{\partial B}{\partial t} &= \delta_B\Delta B - AB^2 - (f+k)B
+\frac{\partial B}{\partial t} &= \delta_B\Delta B + AB^2 - (f+k)B
 \end{align*}
 $$
 


### PR DESCRIPTION
The Gray-Scott reaction term in the $B$ equation is documented as $−AB^2$, but the standard Gray-Scott model and the linked [generation code](https://github.com/danfortunato/spectral-gray-scott/tree/main) use $+AB^2$. This PR corrects the sign in the README.