### PR TITLE
Propagate eps in VRMSE and VMSE

### DIFF
--- a/tests/test_metric.py
+++ b/tests/test_metric.py
@@ -1,6 +1,6 @@
 import torch
 
-from the_well.benchmark.metrics.spatial import MSE, NMSE, NRMSE, RMSE
+from the_well.benchmark.metrics.spatial import MSE, NMSE, NRMSE, RMSE, VMSE, VRMSE
 from the_well.data.datasets import WellMetadata
 
 
@@ -28,3 +28,30 @@ def test_distance_to_itself():
         x = torch.tensor([1.0, 2.0, 3.0]).unsqueeze(-1)
         error = metric(x, x, meta)
         assert torch.allclose(error.nansum(), torch.tensor(0.0))
+
+
+def test_variance_scaled_metrics_propagate_eps():
+    meta = WellMetadata(
+        dataset_name="test",
+        n_spatial_dims=1,
+        spatial_resolution=(128,),
+        scalar_names=[],
+        constant_scalar_names=[],
+        field_names={0: ["test"]},
+        constant_field_names={},
+        boundary_condition_types=["periodic"],
+        n_files=1,
+        n_trajectories_per_file=[10],
+        n_steps_per_trajectory=[100],
+    )
+    # Constant target: the variance is zero, so the result is dominated by
+    # the eps term in the denominator and must therefore depend on eps.
+    y = torch.full((128, 1), 3.0)
+    x = y + 1.0
+    for metric_cls, reference_cls in [(VMSE, NMSE), (VRMSE, NRMSE)]:
+        default_eps = metric_cls.eval(x, y, meta)
+        large_eps = metric_cls.eval(x, y, meta, eps=10.0)
+        assert not torch.allclose(default_eps, large_eps)
+        assert torch.allclose(
+            large_eps, reference_cls.eval(x, y, meta, eps=10.0, norm_mode="std")
+        )

--- a/the_well/benchmark/metrics/spatial.py
+++ b/the_well/benchmark/metrics/spatial.py
@@ -215,7 +215,7 @@ class VMSE(Metric):
         Returns:
             Variance mean squared error between x and y.
         """
-        return NMSE.eval(x, y, meta, norm_mode="std")
+        return NMSE.eval(x, y, meta, eps=eps, norm_mode="std")
 
 
 class VRMSE(Metric):
@@ -237,7 +237,7 @@ class VRMSE(Metric):
         Returns:
             Root variance mean squared error between x and y.
         """
-        return NRMSE.eval(x, y, meta, norm_mode="std")
+        return NRMSE.eval(x, y, meta, eps=eps, norm_mode="std")
 
 
 class LInfinity(Metric):


### PR DESCRIPTION
Fixes #75

`VRMSE.eval` accepts an `eps` parameter but silently drops it when delegating: its body calls `NRMSE.eval(x, y, meta, norm_mode="std")`, so the caller's `eps` is replaced by the 1e-7 default. `VMSE.eval` has the identical pattern with `NMSE.eval`. This is easy to confirm on a zero-variance target, where the result is dominated by the `eps` term in the denominator:

```python
y = torch.full((128, 1), 3.0)  # zero variance
x = y + 1.0
VRMSE.eval(x, y, meta)           # 3162.28
VRMSE.eval(x, y, meta, eps=10.0) # 3162.28 — bit-identical, eps ignored
```

The fix is the minimal one: pass `eps=eps` through in both `VRMSE.eval` and `VMSE.eval`. I audited the other metric classes in `spatial.py` for the same pattern; the remaining delegations either propagate `eps` already (`NRMSE` → `NMSE`) or delegate to `MSE.eval`, which never uses `eps`, so no other call site is affected.

Added a regression test in `tests/test_metric.py`: on a constant target, `eps=10.0` must change the output of `VMSE`/`VRMSE` and must match `NMSE`/`NRMSE` with `norm_mode="std"` and the same `eps`. The test fails on current `master` and passes with this change (`pytest tests/test_metric.py`: 2 passed; `ruff check` / `ruff format` clean under the pre-commit pinned v0.6.4).

Found while running an independent quantified-impact study of the benchmark's metric design; happy to adjust to maintainer preferences.